### PR TITLE
Speedup templates loading and processing.

### DIFF
--- a/scripts/extract_retrieval_features.py
+++ b/scripts/extract_retrieval_features.py
@@ -35,42 +35,59 @@ if __name__ == "__main__":
 
     for idx in range(start_idx, end_idx):
         logger.info(f'Processing {idx+1} / {len(dataset)}')
-        sample = dataset[idx]
+        # Skip if we already processed the file (useful in case of error and restart)
+        if os.path.exists((features_path / f'{dataset.get_model_name(idx)}.npy').as_posix()):
+            logger.info("Model already processed and present on disk. Skipping.")
+            continue
+
+        try:
+            sample = dataset[idx]
+        except KeyError as e:
+            logger.error(f"File missing {e}")
+            continue
         model_name = sample['model_name']
+
+    if sample['templates'] is not None and not os.path.exists((features_path / f'{model_name}.npy').as_posix()):
+        # Move to GPU once, as the batch processing happens
         templates = sample['templates'].to('cuda', dtype=torch.bfloat16)
-        if sample['templates'] is not None:
-            features = []
-            for i in range(0, len(templates), args.batch_size):
-                batch = templates[i:i+args.batch_size]
-                features.append(model(batch, layer=args.layer, feature_type=feature_type))
 
-            features = torch.cat(features, dim=0)
+        # Pre-allocate list for features and compute all batches in one go
+        features = []
+        num_batches = len(templates) // args.batch_size + (len(templates) % args.batch_size != 0)
 
-            if args.feature == 'ffa':
-                avg_feats = []
-                for feat, mask in zip(features, sample['masks']):
-                    # resize mask from 420x420 to 30x30
-                    mask_orig = mask.clone()
-                    mask = cv2.resize(mask.float().numpy(), (30, 30), interpolation=cv2.INTER_AREA) > 0
-                    avg_feat = feat[mask.flatten()]
-                    # average features
+        # Process features in batches
+        for i in range(num_batches):
+            batch = templates[i * args.batch_size : (i + 1) * args.batch_size]
+            features.append(model(batch, layer=args.layer, feature_type=feature_type))
+
+        features = torch.cat(features, dim=0)  # Concatenate features after all batches are processed
+
+        if args.feature == 'ffa':
+            avg_feats = []
+            for feat, mask in zip(features, sample['masks']):
+                # Resize mask from 420x420 to 30x30 using torch for potentially better performance
+                mask_resized = torch.nn.functional.interpolate(mask.unsqueeze(0).unsqueeze(0).float(), size=(30, 30), mode='bilinear', align_corners=False).squeeze()
+                mask_resized = mask_resized > 0
+
+                # Extract features where the mask is valid
+                avg_feat = feat[mask_resized.flatten()]
+                if avg_feat.numel() > 0:
                     avg_feat = avg_feat.mean(dim=0).float().cpu().numpy()
+                else:
+                    avg_feat = np.zeros(feat.shape[0], dtype=np.float32)
 
-                    if np.isnan(avg_feat).any():
-                        logger.warning(f'Feature {model_name} contains NaNs')
-                        logger.warning(f'Mask sum is {mask.sum()}')
-                        logger.warning(f'Mask orig sum is {mask_orig.sum()}')
-                        cv2.imwrite(f'{model_name}_mask_orig.png', mask_orig.numpy().astype(np.uint8) * 255)
-                        cv2.imwrite(f'{model_name}_mask.png', mask.astype(np.uint8) * 255)
-                        continue
-                    else:
-                        avg_feats.append(avg_feat)
+                # Check for NaNs (fewer checks after the loop)
+                if np.isnan(avg_feat).any():
+                    logger.warning(f'Feature {model_name} contains NaNs')
+                    cv2.imwrite(f'{model_name}_mask_orig.png', mask.numpy().astype(np.uint8) * 255)
+                    cv2.imwrite(f'{model_name}_mask.png', mask_resized.numpy().astype(np.uint8) * 255)
+                else:
+                    avg_feats.append(avg_feat)
 
-                avg_feats = np.stack(avg_feats)
-                np.save((features_path / f'{model_name}.npy').as_posix(), avg_feats)
-            else:
-                np.save((features_path / f'{model_name}.npy').as_posix(), features.float().cpu().numpy())
+            avg_feats = np.stack(avg_feats)
+            np.save((features_path / f'{model_name}.npy').as_posix(), avg_feats)
         else:
-            logger.warning(f"Skipping {sample['model_name']}")
-
-    logger.info('Done')
+            # Directly save features if 'ffa' is not the feature type
+            np.save((features_path / f'{model_name}.npy').as_posix(), features.float().cpu().numpy())
+    else:
+        logger.warning(f"Skipping {sample['model_name']}")


### PR DESCRIPTION
The `extract_retrieval_features` script is rather slow as it performs suboptimal operations to load and process the templates. I did some modifications to the scripts and the `WebTemplateDataset` class, which resulted (on my machines) in a speedup by a factor of ~2.5x to ~4x without using SLURM.

Key optimizations:

- Better Tar file access and efficient image handling.
- Better tensor handling
- Batch processing
- Efficient mask resizing and feature calculation
- Fewer `cuda` calls

Extra: I added some initial checks to skip already processed templates. It can be useful in case of uncaught exceptions that break the loop.